### PR TITLE
chore: update commits order and grouping

### DIFF
--- a/docs/pages/build/changelog.mdx
+++ b/docs/pages/build/changelog.mdx
@@ -6,7 +6,7 @@
 
 #### Breaking Changes
 
-- refactor: consolidate BlockEntity boolean fields into status
+- Consolidate BlockEntity boolean fields into status
 - Merged the boolean fields `isAcknowledgedByVulcan`, `isFinalized`, `isRejected`, `isSubmitting` into `BlockStatus` itself.
 - Added `Proposed`, `Submitting` and `Rejected` to `BlockStatus`.
 - Change `BlockStatus.Unknown` -> `BlockStatus.Proposed`.
@@ -16,52 +16,52 @@
 - feat: `C3B` confirmation now comes on Consensus Layer finalization
 - feat: Prune `state_updates` for old finalized blocks
     - Remove all the state updates for actions in the finalized block once it receives C3B. This makes the datastore lighter.
-- Store `fuelConsumed` in DB along with BlockData
+- feat: Store `fuelConsumed` in DB along with BlockData
 - feat: store `l1BlockNumber` and use it for query while doing C3B finalization
+- feat: add `Block` object (*containing height, timestamp and parentHash*) in STF
+- feat: new Bridge plugin
+- feat: expose `actions.query` in MicroRollupResponse
+
 
 #### Other changes
 
-- fix: [PLAYGROUND] remove 404 handler
-- chore: add Bytes32 to Solidity type
-- fix: Respect logLevel for playground plugins logs
-- fix: use `ZeroHash` as parentHash of first block
-- new [PLUGIN]: Bridge plugin in SDK
-- perf: optimizations for fetch actions & acks
-- fix: use `stfSchemaMap` to validate actions as per schema based on defined Transition functions
 - feat: store & send `l1Metadata` with block
-- refactor: getBlockByActionHash
-- chore: add local server link in playground logs
-- fix: remove `l1RPC` from playground config
-- feat: add `Block` object (*containing height, timestamp and parentHash*) in STF
-- fix: create partial block in DB & create one block at a time.
 - feat: `positionInBlock` for actions
 - feat: emit `ChainEvents.REORG` event
+- feat: Support new Block Status Response
+- feat: check `minSupportedSDKVersion` from Vulcan Healthcheck
+- perf: optimizations for fetch actions & acks
+- fix: [PLAYGROUND] remove 404 handler
+- fix: Respect logLevel for playground plugins logs
+- fix: use `ZeroHash` as parentHash of first block
+- fix: use `stfSchemaMap` to validate actions as per schema based on defined Transition functions
+- fix: remove `l1RPC` from playground config
+- fix: create partial block in DB & create one block at a time.
 - fix: backfill pending actions from DB to pool on bootup
 - fix: execute & sequence unfinalized blocks on bootup
 - fix: sync missed BlockSubmitted L1 events on bootup
-- feat: Support new Block Status Response
-- feat: check `minSupportedSDKVersion` from Vulcan Healthcheck
-- feat: expose `actions.query` in MicroRollupResponse
 - fix: State revert to Genesis in case of first action getting rejected [BUG]
-- fix: validate genesis state and getRootHash at MRU init
 - fix: await for `advanceActionExecution` and then enqueue [BUG]
+- fix: validate genesis state and getRootHash at MRU init
 - refactor: Remove internal Datastore
+- refactor: getBlockByActionHash
+- chore: add local server link in playground logs
+- chore: add Bytes32 to Solidity type
 - chore: add lint rule for no-floating-promises and all occurrences of no-floating-promises
 - test: `BlockService.updateBlockState` and few more
 
 ### CLI
 
-- fix: handle quote in `.env` values
-- feat: Support default export and declaration export
-- fix: handle errors globally
+- feat: Support default export and declaration export for State Machines
 - feat: Update datastore in config & fixes in query config
-- fix: use `process.env.DB_URI` as default
+- feat: [COMMAND] `transfer-ownership` along with `--privateKey` support 
+- feat: add `--privateKey` flag support for for `register` and `deploy`
+- feat: [COMMAND] `add <entity> <address>` changes `add-bridge` to `add bridge`
 - docs: Add docker instructions in README
+- fix: handle quote in `.env` values
+- fix: handle errors globally
+- fix: use `process.env.DB_URI` as default
 - fix: don't ask if when no database
-- feat: add `--privateKey` support for  for `register` and `deploy`
-- [COMMAND] `add <entity> <address>`
-- Changing `add-bridge` to `add bridge`
-- [COMMAND] `transfer-ownership` along with `--privateKey` support 
 
 ### go-daash
 


### PR DESCRIPTION
## Description

This PR re-orders/re-groups the commits in Release Notes

Also, these are the highlights
<img width="754" alt="image" src="https://github.com/stackrlabs/docs/assets/21199234/64c408a7-6d30-48bb-964e-16c1b28b8e46">
